### PR TITLE
Compatibility for Pianoteq 9 binary

### DIFF
--- a/build
+++ b/build
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 FORCE_REBUILD=0
 

--- a/build
+++ b/build
@@ -30,7 +30,7 @@ done
 
 if [ $FORCE_REBUILD ] || [ -z "$(docker image ls | grep pianoberry-build)" ]; then
   echo "Building pianoberry-build image"
-  docker rmi $(docker images | grep 'pianoberry-build' | awk '{print $3}')
+  docker rmi $(docker images | grep 'pianoberry-build' | awk '{print $2}')
   docker build --no-cache -q -t pianoberry-build .
 fi
 

--- a/pianoberry/build
+++ b/pianoberry/build
@@ -88,11 +88,11 @@ cd /pianoberry/pianoberry
 
 unzip /build/src/piCore64-15.0.0.zip
 
-dd bs=512 seek=529999 of=pianoberry.img < /dev/null
+dd bs=512 seek=532479 of=pianoberry.img < /dev/null
 parted --script pianoberry.img \
 	mklabel msdos \
-	mkpart primary fat32 8192s 303615s \
-	mkpart primary ext4 303616s 100%
+	mkpart primary fat32 8192s 305151s \
+	mkpart primary ext4 305152s 100%
 
 TARGET_LOOP=$(kpartx -av pianoberry.img | awk 'NR==1 {print substr($3, 1, length($3)-2)}')
 

--- a/pianoberry/build
+++ b/pianoberry/build
@@ -88,11 +88,11 @@ cd /pianoberry/pianoberry
 
 unzip /build/src/piCore64-15.0.0.zip
 
-dd bs=512 seek=471039 of=pianoberry.img < /dev/null
+dd bs=512 seek=529999 of=pianoberry.img < /dev/null
 parted --script pianoberry.img \
 	mklabel msdos \
-	mkpart primary fat32 8192s 243711s \
-	mkpart primary ext4 243712s 100%
+	mkpart primary fat32 8192s 303615s \
+	mkpart primary ext4 303616s 100%
 
 TARGET_LOOP=$(kpartx -av pianoberry.img | awk 'NR==1 {print substr($3, 1, length($3)-2)}')
 


### PR DESCRIPTION
Extending first partition of the image for about 29MB. This will make enough space for adding the full Pianoteq 9 binary on the sd card after flashing the image.

fixes #7